### PR TITLE
Drop Python 3.13t (free-threaded) wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,10 +62,8 @@ jobs:
           - [windows-2022, win_amd64, ""]
           - [windows-2022, win32, ""]
           - [windows-11-arm, win_arm64, ""]
-        python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        python: ["cp312", "cp313", "cp314", "cp314t"]
         exclude:
-          - buildplat: [ macos-15-intel, macosx_x86_64, openblas ]
-            python: "cp313t"
           - buildplat: [ macos-15-intel, macosx_x86_64, openblas ]
             python: "cp314t"
         include:

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -6,7 +6,7 @@ skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 before-test = "pip install -r {project}/requirements/wheel_test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
-enable = ["pypy", "cpython-prerelease"]
+enable = ["cpython-prerelease"]
 
 # The build will use openblas64 everywhere, except on arm64 macOS >=14.0 (uses Accelerate)
 [tool.cibuildwheel.config-settings]

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -6,7 +6,7 @@ skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 before-test = "pip install -r {project}/requirements/wheel_test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
-enable = ["cpython-freethreading", "pypy", "cpython-prerelease"]
+enable = ["pypy", "cpython-prerelease"]
 
 # The build will use openblas64 everywhere, except on arm64 macOS >=14.0 (uses Accelerate)
 [tool.cibuildwheel.config-settings]


### PR DESCRIPTION
See https://cibuildwheel.pypa.io/en/stable/changelog/#v341, this functionality will be removed in the next minor release of cibuildwheel.