### PR TITLE
BLD: Set SOURCE_REF_TO_BUILD to maintenance/2.5.x

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,7 +4,7 @@ env:
   # A tag or branch name or a commit hash for the numpy/numpy repo, for which
   # to build wheels. This is normally set to `main` in the main branch of this
   # repo, and to a tag name (e.g., `v2.3.2`) on a release branch.
-  SOURCE_REF_TO_BUILD: main
+  SOURCE_REF_TO_BUILD: maintenance/2.5.x
 
 on:
   schedule:


### PR DESCRIPTION
Needed for new branches in the numpy-release repo.